### PR TITLE
add auto_series_param

### DIFF
--- a/torch_dreams/__init__.py
+++ b/torch_dreams/__init__.py
@@ -4,6 +4,7 @@ from .model_bunch import *
 from .tests import *
 from .auto_image_param import AutoImageParam
 from .custom_image_param import CustomImageParam
+from .auto_series_param import AutoSeriesParam
 
 __version__ = "4.0.0"
 
@@ -12,6 +13,7 @@ __all__ = [
     "utils",
     "model_bunch",
     "auto_image_param",
+    "auto_series_param.py",
     "custom_image_param",
     "masked_image_param",
     "image_transforms",

--- a/torch_dreams/auto_series_param.py
+++ b/torch_dreams/auto_series_param.py
@@ -1,0 +1,180 @@
+import torch
+
+from .utils import init_series_param
+from .utils import fft_to_series
+
+
+class BaseSeriesParam(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.channels = None
+        self.length = None
+        self.param = None
+        self.optimizer = None
+
+    def forward(self):
+        """This is what the model gets, should be processed and normalized with the right values
+
+        The model gets:  self.normalize(self.postprocess(self.param))
+
+        Raises:
+            NotImplementedError: Implemented below, you're in the base class.
+        """
+        raise NotImplementedError
+
+    def postprocess(self):
+        """Moves the series from the frequency domain to Spatial (Visible to the eyes)
+
+        Raises:
+            NotImplementedError: Implemented below, you're in the base class.
+        """
+        raise NotImplementedError
+
+    def normalize(self):
+        """Normalizing wrapper, you can either use torchvision.transforms.Normalize() or something else
+
+        Raises:
+            NotImplementedError: Implemented below, you're in the base class.
+        """
+        raise NotImplementedError
+
+    def fetch_optimizer(self, params_list, optimizer=None, lr=1e-3, weight_decay=0.0):
+        if optimizer is not None:
+            optimizer = optimizer(params_list, lr=lr, weight_decay=weight_decay)
+        else:
+            optimizer = torch.optim.AdamW(params_list, lr=lr, weight_decay=weight_decay)
+        return optimizer
+
+    def get_optimizer(self, lr, weight_decay):
+        self.optimizer = self.fetch_optimizer(
+            params_list=[self.param], lr=lr, weight_decay=weight_decay
+        )
+
+    def clip_grads(self, grad_clip=1.0):
+        torch.nn.utils.clip_grad_norm_(self.param, grad_clip)
+
+    def to_cl_tensor(self, device="cpu"):
+        """Return CL series tensor (channels, length).
+
+        Args:
+            device (str):  The device to operate on ('cpu' or 'cuda').
+
+        Returns:
+            torch.Tensor
+        """
+        t = self.postprocess(device=device)[0].detach()
+        return t
+
+    def to_lc_tensor(self, device="cpu"):
+        """Return LC series tensor (length, channels).
+
+        Args:
+            device (str):  The device to operate on ('cpu' or 'cuda').
+
+        Returns:
+            torch.Tensor
+        """
+        t = self.postprocess(device=device)[0].permute(1, 0).detach()
+        return t
+
+    def __array__(self):
+        """Generally used for plt.imshow(), converts the series parameter to a NCL numpy array
+
+        Returns:
+            numpy.ndarray
+        """
+        return self.to_cl_tensor().numpy()
+
+    def save(self, filename):
+        """Save an image_param as an image. Uses PIL to save the image
+
+        usage:
+
+            image_param.save(filename = 'my_image.jpg')
+
+        Args:
+            filename (str): image.jpg
+        """
+        tensor = self.to_cl_tensor()
+        torch.save(tensor, filename)
+
+
+class AutoSeriesParam(BaseSeriesParam):
+    """Trainable series parameter which can be used to activate
+       different parts of a neural net
+
+    Args:
+        length (int): The sequence length of the series
+        channels (int): The number of channels of the series
+
+        device (str): 'cpu' or 'cuda'
+        standard_deviation (float): Standard deviation of the series initiated
+         in the frequency domain.
+        batch_size (int): The batch size of the input tensor. If batch_size=1,
+         no batch dimension is expected.
+    """
+
+    def __init__(self, length, channels, device, standard_deviation, batch_size: int = 1):
+        self.length = length
+        self.channels = channels
+        self.standard_deviation = standard_deviation
+        self.batch_size = batch_size
+        self.device = device
+
+        self.optimizer = None
+
+        """
+        odd length is resized to even with one extra element
+        """
+        if self.length % 2 == 1:
+            self.param = init_series_param(
+                channels=self.channels,
+                length=self.length + 1,
+                sd=standard_deviation,
+                device=device,
+            )
+        else:
+            self.param = init_series_param(
+                channels=self.channels,
+                length=self.length,
+                sd=standard_deviation,
+                device=device,
+            )
+        self.param.requires_grad_()
+
+    def postprocess(self, device):
+        series = fft_to_series(
+            channels=self.channels,
+            length=self.length,
+            series_parameter=self.param,
+            device=device,
+        )
+        #TODO: img = lucid_colorspace_to_rgb(t=img, device=device)
+        series = torch.sigmoid(series)
+        return series
+
+    def forward(self, device):
+        # TODO: add normalization
+        if self.batch_size == 1:
+            return self.postprocess(device=device)
+        else:
+            return torch.cat(
+                [
+                    self.postprocess(device=device)
+                    for i in range(self.batch_size)
+                ],
+                dim=0,
+            )
+
+    def fetch_optimizer(self, params_list, optimizer=None, lr=1e-3, weight_decay=0.0):
+        if optimizer is not None:
+            optimizer = optimizer(params_list, lr=lr, weight_decay=weight_decay)
+        else:
+            optimizer = torch.optim.AdamW(params_list, lr=lr, weight_decay=weight_decay)
+        return optimizer
+
+    def get_optimizer(self, lr, weight_decay):
+
+        self.optimizer = self.fetch_optimizer(
+            params_list=[self.param], lr=lr, weight_decay=weight_decay
+        )

--- a/torch_dreams/series_transforms.py
+++ b/torch_dreams/series_transforms.py
@@ -1,0 +1,99 @@
+import numbers
+from collections.abc import Sequence
+
+import torch
+
+
+class RandomSeriesTranslate(torch.nn.Module):
+
+    def __init__(
+        self,
+        translate: float,
+        fill=0,
+    ):
+        super().__init__()
+
+        if not isinstance(translate, numbers.Number):
+            raise TypeError(f"translate should be a number but is {type(translate)}.")
+            if not (0.0 <= translate <= 1.0):
+                raise ValueError("translation value should be between 0 and 1")
+        self.translate = translate
+
+        if fill is None:
+            fill = 0
+        elif not isinstance(fill, (Sequence, numbers.Number)):
+            raise TypeError("Fill should be either a sequence or a number.")
+
+        self.fill = fill
+
+    def forward(self, series):
+        fill = self.fill
+        channels, length = _get_series_dimensions(series)
+
+        max_shift = float(self.translate * length)
+        shift = int(round(torch.empty(1).uniform_(-max_shift, max_shift).item()))
+
+        out = torch.roll(series, shift, dims=-1)
+
+        if fill is not None and not isinstance(fill, (float, int)):
+            fill = torch.FloatTensor(fill)[:shift]
+
+        if fill is not None and shift > 0:
+            out[..., :shift] = fill
+
+        if fill is not None and shift < 0:
+            out[..., -shift:] = fill
+
+        return out
+
+
+class RandomSeriesScale(torch.nn.Module):
+
+    def __init__(
+        self,
+        min_scale: float,
+        max_scale: float,
+    ):
+        super().__init__()
+
+        if not isinstance(min_scale, numbers.Number):
+            raise TypeError(f"min_scale should be a number but is {type(min_scale)}.")
+        if not isinstance(max_scale, numbers.Number):
+            raise TypeError(f"max_scale should be a number but is {type(max_scale)}.")
+
+        self.min_scale = min_scale
+        self.max_scale = max_scale
+
+    def forward(self, series):
+        scale = torch.empty(1).uniform_(self.min_scale, self.max_scale)
+        out = series * scale
+        return out
+
+
+def _check_sequence_input(x, name, req_sizes):
+    msg = req_sizes[0] if len(req_sizes) < 2 else " or ".join([str(s) for s in req_sizes])
+    if not isinstance(x, Sequence):
+        raise TypeError(f"{name} should be a sequence of length {msg}.")
+    if len(x) not in req_sizes:
+        raise ValueError(f"{name} should be a sequence of length {msg}.")
+
+def _setup_angle(x, name, req_sizes=(2,)):
+    if isinstance(x, numbers.Number):
+        if x < 0:
+            raise ValueError(f"If {name} is a single number, it must be positive.")
+        x = [-x, x]
+    else:
+        _check_sequence_input(x, name, req_sizes)
+
+    return [float(d) for d in x]
+
+
+def _get_series_dimensions(series):
+    # TODO:  _assert_image_tensor(img)
+    if series.ndim == 1:
+        channels = 1
+        length = len(series)
+    else:
+        channels = series.shape[-2]
+        length = series.shape[-1]
+    return [channels, length]

--- a/torch_dreams/tests/test_series.py
+++ b/torch_dreams/tests/test_series.py
@@ -1,0 +1,120 @@
+import os
+
+import numpy as np
+import pytest
+import torch
+import torchvision.transforms as transforms
+
+from torch_dreams import Dreamer
+from torch_dreams.auto_series_param import AutoSeriesParam
+from torch_dreams.series_transforms import RandomSeriesScale
+from torch_dreams.series_transforms import RandomSeriesTranslate
+from torch_dreams.transforms import random_resize
+
+
+class CNN1d(torch.nn.Module):
+    def __init__(self, in_channels, out_features, channels=25):
+        super(CNN1d, self).__init__()
+        self.conv1 = torch.nn.Conv1d(in_channels, channels, kernel_size=5, stride=2, padding=1)
+        self.conv2 = torch.nn.Conv1d(channels, channels, kernel_size=3, stride=2, padding=1)
+        self.conv3 = torch.nn.Conv1d(channels, channels, kernel_size=3, stride=2, padding=1)
+        self.flatten = torch.nn.Flatten()
+        self.fc = torch.nn.LazyLinear(out_features)
+
+    def forward(self, x):
+        h1 = self.conv1(x).relu()
+        h2 = self.conv2(h1).relu()
+        h3 = self.conv3(h2).relu()
+        return self.fc(self.flatten(h3))
+
+
+@pytest.mark.parametrize("out_features", [3, 10, 21])
+@pytest.mark.parametrize("sequence_length", [11, 20, 40, 99, 1000])
+@pytest.mark.parametrize("channels", [1, 2, 10, 59])
+@pytest.mark.parametrize("batch_size", [1, 16, 64, 256])
+def test_cnn_model_outputs_correct_shape(sequence_length, channels, out_features, batch_size):
+    model = CNN1d(in_channels=channels, out_features=out_features)
+    x = torch.zeros((batch_size, channels, sequence_length))
+
+    assert model(x).shape == (batch_size, out_features)
+
+
+@pytest.mark.parametrize("iters", [1, 2, 10, 20])
+@pytest.mark.parametrize("sequence_length", [11, 20, 40, 99, 1000])
+@pytest.mark.parametrize("channels", [1, 2, 10, 59])
+@pytest.mark.parametrize("batch_size", [1])
+def test_auto_series_param(iters, sequence_length, channels, batch_size):
+    model = CNN1d(in_channels=channels, out_features=10)
+
+    # Prepare lazy modules.
+    x = torch.zeros((batch_size, channels, sequence_length))
+    y = model(x)
+
+    series_param = AutoSeriesParam(
+        length=sequence_length,
+        channels=channels,
+        device="cpu",
+        standard_deviation=0.01,
+        batch_size=batch_size,
+    )
+
+    series_transforms = transforms.Compose(
+        [
+            RandomSeriesTranslate(0.1),
+            RandomSeriesScale(0.5, 1.2),
+        ]
+    )
+
+    dreamy_boi = Dreamer(model=model, device='cpu', quiet=False)
+    dreamy_boi.set_custom_transforms(series_transforms)
+
+    result = dreamy_boi.render(
+        layers=[model.conv1],
+        iters=iters,
+        image_parameter=series_param,
+    )
+
+    assert isinstance(result, AutoSeriesParam), "should be an instance of auto_series_param"
+    assert isinstance(result.__array__(), np.ndarray)
+    assert isinstance(result.to_cl_tensor(), torch.Tensor), "should be a torch.Tensor"
+    assert isinstance(result.to_lc_tensor(), torch.Tensor), "should be a torch.Tensor"
+    assert result.to_cl_tensor().shape == x[0].shape
+
+def test_auto_series_save(iters=2, sequence_length=40, channels=2, batch_size=1):
+    model = CNN1d(in_channels=channels, out_features=10)
+
+    # Prepare lazy modules.
+    x = torch.zeros((batch_size, channels, sequence_length))
+    y = model(x)
+
+    series_param = AutoSeriesParam(
+        length=sequence_length,
+        channels=channels,
+        device="cpu",
+        standard_deviation=0.01,
+    )
+
+    translate = 0.1
+    scale_max = 1.2
+    scale_min = 0.5
+
+    series_transforms = transforms.Compose(
+        [
+            RandomSeriesTranslate(0.1),
+            RandomSeriesScale(0.5, 1.2),
+        ]
+    )
+
+    dreamy_boi = Dreamer(model=model, device='cpu', quiet=False)
+    dreamy_boi.set_custom_transforms(series_transforms)
+
+    result = dreamy_boi.render(
+        layers=[model.conv1],
+        iters=iters,
+        image_parameter=series_param,
+    )
+
+    filename = f"test_ts_single_model.jpg"
+    result.save(filename=filename)
+    assert os.path.exists(filename)
+    os.remove(filename)


### PR DESCRIPTION
The current state of the package only supports 2d image-type input. Theorywise, it shouldn't be a problem to apply the functionality to time series inputs.

This PR adds the class `AutoSeriesParam`, which is designed according to `AutoImageParam`, but supports sequences instead of images. This way 1d-support can be integrated neatly without changing any existing code.

It is therefore needed to to setup the dreamer manually this way:

```python
    series_param = AutoSeriesParam(
        length=sequence_length,
        channels=channels,
        standard_deviation=0.01,
        batch_size=batch_size,
        device="cpu",
    )

    series_transforms = transforms.Compose(
        [
            RandomSeriesTranslate(0.1),
            RandomSeriesScale(0.5, 1.2),
        ]
    )

    dreamy_boi = Dreamer(model=model, device='cpu', quiet=False)
    dreamy_boi.set_custom_transforms(series_transforms)

    result = dreamy_boi.render(
        layers=[model.conv1],
        iters=10,
        image_parameter=series_param,
    )
```

Maybe the series transforms could be setup by default in the dreamer, if the image_parameter is an instance of `BaseSeriesParam`?

There are still some issues left where I am unsure what to do:

1. The `AutoImageParam` class has a `normalize()` method to normalize the output. It uses imagenet mean and std to apply z-score standardization. There's no such equivalent in time series data due to their heterogeneous nature so we need a way to feed in the mean and std values. The `Dreamer` class has a `set_custom_normalization()` method for this use, but the `InverseTransform` relies on 4d-tensors. I'm not sure how to integrate time series support into this.

2. The `AutoImageParam.postprocess()` method applies the function `lucid_colorspace_to_rgb()`. I don't really understand what it does and I'm clueless on how to treat this in the time series domain.

3. I left out the implementation of a `CustomSeriesParam` class for now, but that should come in a follow-up PR.