### PR TITLE
added the imageio instead of opencv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=1.8.0
 torchvision>=0.8.1
-opencv-python
+imageio
 numpy
 tqdm
 mkl

--- a/torch_dreams/custom_image_param.py
+++ b/torch_dreams/custom_image_param.py
@@ -1,7 +1,8 @@
 from .auto_image_param import BaseImageParam
 
-import cv2 
+
 import torch
+import imageio
 
 from .utils import (
     lucid_colorspace_to_rgb, 
@@ -42,9 +43,10 @@ class CustomImageParam(BaseImageParam):
         
         super().__init__()
         self.device = device
+        #use imageio to read the image
         if isinstance(image, str):
-            image = cv2.cvtColor(cv2.imread(image), cv2.COLOR_BGR2RGB)/255.
-            image = torch.tensor(image).permute(-1,0,1).unsqueeze(0)
+            image = imageio.imread(image) / 255.0
+            image = torch.tensor(image).permute(2, 0, 1).unsqueeze(0)
         self.set_param(image)
 
     def normalize(self,x, device):

--- a/torch_dreams/masked_image_param.py
+++ b/torch_dreams/masked_image_param.py
@@ -1,4 +1,4 @@
-import cv2
+import imageio
 import torch
 from .custom_image_param import CustomImageParam
 from .transforms import imagenet_transform
@@ -48,8 +48,8 @@ class MaskedImageParam(CustomImageParam):
         self.mask = mask_tensor.to(self.device)
 
         if isinstance(image, str):
-            image = cv2.cvtColor(cv2.imread(image), cv2.COLOR_BGR2RGB) / 255.0
-            image = torch.tensor(image).permute(-1, 0, 1).unsqueeze(0)
+            image = imageio.imread(image) / 255.0
+            image = torch.tensor(image).permute(2, 0, 1).unsqueeze(0)
 
         self.original_nchw_image_tensor = image.to(device)
 


### PR DESCRIPTION
close #56 


**Replace OpenCV with imageio for Image Reading and Normalization**

This update modifies the `CustomImageParam`  and  `MaskedImageParam` class to remove its dependency on OpenCV for reading images and converting color spaces. Instead, we utilize `imageio`, which simplifies the process by natively reading images in the desired RGB format and allows for direct normalization without additional steps. The primary change is in the `__init__` method, where we replaced OpenCV operations with `imageio` functionality.

**Changes:**

- Removed import for `cv2`.
- Added import for `imageio`.
- Updated the `__init__` method to use `imageio.imread` for reading the image, automatically handling RGB conversion and normalization.

**Code Change:**

```python
# Before:
import cv2
...
if isinstance(image, str):
    image = cv2.cvtColor(cv2.imread(image), cv2.COLOR_BGR2RGB)/255.
    image = torch.tensor(image).permute(-1,0,1).unsqueeze(0)

# After:
import imageio
...
if isinstance(image, str):
    image = imageio.imread(image) / 255.0  # Reads in RGB and normalizes
    image = torch.tensor(image).permute(2, 0, 1).unsqueeze(0)
```

This modification significantly reduces the dependency footprint by eliminating the need for OpenCV, which is a larger library used minimally in this context. It simplifies the codebase and leverages `imageio` for efficient image processing, making the project lighter and more focused on its specific requirements.
